### PR TITLE
fix(feature): fix field-mapper conditions to disable select

### DIFF
--- a/src/components/feature/field-mapper.tsx
+++ b/src/components/feature/field-mapper.tsx
@@ -111,7 +111,10 @@ export function FieldMapperField(props: Props) {
 
   const { data: fieldInputOptions, isFetching: isFetchingFieldInput } =
     useFieldOptions({
-      enabled: Boolean(props.value.mainInput && props.value.dependentInput),
+      enabled: Boolean(
+        props.value.mainInput &&
+          (!options?.dependentInputSource || props.value.dependentInput),
+      ),
       integration: props.integration,
       sourceType: options?.fieldSource.cacheKey as string,
       parameters,
@@ -268,7 +271,11 @@ export function FieldMapperField(props: Props) {
               isFetching={isFetchingFieldInput}
               onDebouncedChange={setFieldInputSearch}
               size="sm"
-              disabled={!props.value.mainInput || !props.value.dependentInput}
+              disabled={Boolean(
+                !props.value.mainInput ||
+                  (options?.dependentInputSource &&
+                    !props.value.dependentInput),
+              )}
               allowClear
             >
               {fieldInputOptions.data.map((option) => {


### PR DESCRIPTION
### Issues Closed
- PARA-15422

### Brief Summary
Fix field-mapper component to only require dependent input when it's actually needed, improving user experience by removing unnecessary form validation requirements.

### Detailed Summary
The field-mapper component was incorrectly requiring users to fill in dependent input fields even when they weren't necessary for the field mapping. This created unnecessary friction in the user experience. The fix updates the conditional logic to only require dependent input when `dependentInputSource` is actually configured, allowing users to proceed with field mapping when only the main input is required.

### Changes
- **Modified `src/components/feature/field-mapper.tsx`**:
  - Updated `useFieldOptions` hook condition to only fetch when mainInput exists AND either dependentInputSource doesn't exist OR dependentInput is provided
  - Updated select field disabled condition to only disable when mainInput is missing OR when dependentInputSource exists but dependentInput is missing
  - Improved conditional logic readability with explicit Boolean wrapping

### Steps to Test
1. Navigate to a field-mapper component in the application
2. Test scenario 1: When `dependentInputSource` is not configured
   - Select a main input value
   - Verify the select field becomes enabled immediately
   - Verify the useFieldOptions hook fetches data
3. Test scenario 2: When `dependentInputSource` is configured
   - Select a main input value
   - Verify the select field remains disabled until dependent input is also selected
   - Verify the useFieldOptions hook only fetches after both inputs are provided
4. Test clearing main input disables the select field in both scenarios
5. Verify all existing field mapping functionality continues to work as expected

### QA Notes
- Focus testing on field-mapper components that have different dependent input configurations
- Pay special attention to edge cases where dependent input might be optional vs required
- Verify no regression in existing field mapping workflows

### Screenshots
N/A - This is a logic fix that improves form behavior without visual changes