### PR TITLE
feat: TriggerKit support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@radix-ui/react-slot": "^1.2.4",
         "@tanstack/react-query": "^4.36.1",
         "@tanstack/react-query-devtools": "^4.42.0",
-        "@useparagon/connect": "2.4.0-experimental.1",
+        "@useparagon/connect": "2.4.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -3663,9 +3663,9 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="
     },
     "node_modules/@useparagon/connect": {
-      "version": "2.4.0-experimental.1",
-      "resolved": "https://registry.npmjs.org/@useparagon/connect/-/connect-2.4.0-experimental.1.tgz",
-      "integrity": "sha512-bRFjJrzdjhrLx6pOjxHV1q9/kYdswXnmqSN/qYvkGX1tq7dEvolcI/nzV4PC2kCdwbF95iyzlSm+46lAUahFXQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@useparagon/connect/-/connect-2.4.0.tgz",
+      "integrity": "sha512-sVyDIY4Yv4B0xqf7lhWGFYLNZ43FO3ZecHkigJfN3anJ5dTuFur/4y0JG+AswJRBlKhv6GamCptt1bCEZSQ7MQ==",
       "dependencies": {
         "clone-deep": "^4.0.1",
         "hash.js": "^1.1.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@radix-ui/react-slot": "^1.2.4",
         "@tanstack/react-query": "^4.36.1",
         "@tanstack/react-query-devtools": "^4.42.0",
-        "@useparagon/connect": "2.4.0-experimental-19855.2",
+        "@useparagon/connect": "2.4.0-experimental.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -3663,27 +3663,18 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="
     },
     "node_modules/@useparagon/connect": {
-      "version": "2.4.0-experimental-19855.2",
-      "resolved": "https://registry.npmjs.org/@useparagon/connect/-/connect-2.4.0-experimental-19855.2.tgz",
-      "integrity": "sha512-oriS+1velJnOdms3kBhPoh3S3pSPbr8lGFWKWm2bMWtu5Ovut/PO3K4z46j/Ug2ZnCsGf/9Ffbs/g717n/ddOg==",
+      "version": "2.4.0-experimental.1",
+      "resolved": "https://registry.npmjs.org/@useparagon/connect/-/connect-2.4.0-experimental.1.tgz",
+      "integrity": "sha512-bRFjJrzdjhrLx6pOjxHV1q9/kYdswXnmqSN/qYvkGX1tq7dEvolcI/nzV4PC2kCdwbF95iyzlSm+46lAUahFXQ==",
       "dependencies": {
         "clone-deep": "^4.0.1",
         "hash.js": "^1.1.7",
         "jwt-decode": "^3.1.2",
-        "react": "^17.0.2",
+        "lodash": "^4.17.23",
         "tslib": "2.3.1"
-      }
-    },
-    "node_modules/@useparagon/connect/node_modules/react": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
       },
-      "engines": {
-        "node": ">=0.10.0"
+      "peerDependencies": {
+        "react": "^17 || ^18 || ^19"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -5790,14 +5781,6 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@radix-ui/react-slot": "^1.2.4",
         "@tanstack/react-query": "^4.36.1",
         "@tanstack/react-query-devtools": "^4.42.0",
-        "@useparagon/connect": "2.4.0-experimental-19855.1",
+        "@useparagon/connect": "2.4.0-experimental-19855.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -3663,9 +3663,9 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="
     },
     "node_modules/@useparagon/connect": {
-      "version": "2.4.0-experimental-19855.1",
-      "resolved": "https://registry.npmjs.org/@useparagon/connect/-/connect-2.4.0-experimental-19855.1.tgz",
-      "integrity": "sha512-LN7lp6yFaDRsKDYiK5j23sibEvWokEp2SDU15ZeJbh3bHSjKHtTHHB9OI+KX4NmfD7F/EpX5TYTMKMStpQ9Nbw==",
+      "version": "2.4.0-experimental-19855.2",
+      "resolved": "https://registry.npmjs.org/@useparagon/connect/-/connect-2.4.0-experimental-19855.2.tgz",
+      "integrity": "sha512-oriS+1velJnOdms3kBhPoh3S3pSPbr8lGFWKWm2bMWtu5Ovut/PO3K4z46j/Ug2ZnCsGf/9Ffbs/g717n/ddOg==",
       "dependencies": {
         "clone-deep": "^4.0.1",
         "hash.js": "^1.1.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@radix-ui/react-slot": "^1.2.4",
         "@tanstack/react-query": "^4.36.1",
         "@tanstack/react-query-devtools": "^4.42.0",
-        "@useparagon/connect": "2.3.0",
+        "@useparagon/connect": "2.4.0-experimental-19855.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -3663,9 +3663,9 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="
     },
     "node_modules/@useparagon/connect": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@useparagon/connect/-/connect-2.3.0.tgz",
-      "integrity": "sha512-eB9z39t6vIY5EqOoKFJyjQLij6aMfnkMj6pptbE7p2D/WNAuesh4FZ3tvdqRxG6YoFfCJwyHOTXL+JLGBgGhyg==",
+      "version": "2.4.0-experimental-19855.1",
+      "resolved": "https://registry.npmjs.org/@useparagon/connect/-/connect-2.4.0-experimental-19855.1.tgz",
+      "integrity": "sha512-LN7lp6yFaDRsKDYiK5j23sibEvWokEp2SDU15ZeJbh3bHSjKHtTHHB9OI+KX4NmfD7F/EpX5TYTMKMStpQ9Nbw==",
       "dependencies": {
         "clone-deep": "^4.0.1",
         "hash.js": "^1.1.7",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@radix-ui/react-slot": "^1.2.4",
     "@tanstack/react-query": "^4.36.1",
     "@tanstack/react-query-devtools": "^4.42.0",
-    "@useparagon/connect": "2.4.0-experimental.1",
+    "@useparagon/connect": "2.4.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@radix-ui/react-slot": "^1.2.4",
     "@tanstack/react-query": "^4.36.1",
     "@tanstack/react-query-devtools": "^4.42.0",
-    "@useparagon/connect": "2.4.0-experimental-19855.2",
+    "@useparagon/connect": "2.4.0-experimental.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@radix-ui/react-slot": "^1.2.4",
     "@tanstack/react-query": "^4.36.1",
     "@tanstack/react-query-devtools": "^4.42.0",
-    "@useparagon/connect": "2.3.0",
+    "@useparagon/connect": "2.4.0-experimental-19855.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@radix-ui/react-slot": "^1.2.4",
     "@tanstack/react-query": "^4.36.1",
     "@tanstack/react-query-devtools": "^4.42.0",
-    "@useparagon/connect": "2.4.0-experimental-19855.1",
+    "@useparagon/connect": "2.4.0-experimental-19855.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/src/components/feature/dynamic-enum.tsx
+++ b/src/components/feature/dynamic-enum.tsx
@@ -8,7 +8,12 @@ import { useMemo, useState } from 'react';
 import Fuse from 'fuse.js';
 
 import { ComboboxField } from '@/components/form/combobox-field';
+import { ComboboxOptions } from '@/components/form/combobox-options';
 import { PaginatedCombobox } from '@/components/form/paginated-combobox';
+import {
+  findFieldOption,
+  flattenFieldOptions,
+} from '@/lib/field-options';
 import {
   hasSourcePagination,
   useFieldOptions,
@@ -92,14 +97,20 @@ function StaticDynamicEnum(
     source: props.dynamicSource,
   });
 
+  const rawData = useMemo(() => options?.data ?? [], [options?.data]);
+  const flatOptions = useMemo(() => flattenFieldOptions(rawData), [rawData]);
+
+  // Preserve section grouping at rest, but collapse to a flat fuse-filtered
+  // result list while the user is actively searching.
+  const isSearching = Boolean(props.search.trim());
   const filteredOptions = useMemo(
-    () => filterOptions(options?.data ?? [], props.search),
-    [options?.data, props.search],
+    () => (isSearching ? filterOptions(flatOptions, props.search) : []),
+    [isSearching, flatOptions, props.search],
   );
 
   const selectedOption = useMemo(
-    () => filteredOptions.find((option) => option.value === props.value),
-    [filteredOptions, props.value],
+    () => findFieldOption(rawData, props.value),
+    [rawData, props.value],
   );
 
   return (
@@ -114,11 +125,11 @@ function StaticDynamicEnum(
       onDebouncedChange={props.onSearchChange}
       allowClear
     >
-      {filteredOptions.map((option) => (
-        <ComboboxField.Item key={option.value} value={option.value}>
-          {option.label}
-        </ComboboxField.Item>
-      ))}
+      {isSearching ? (
+        <ComboboxOptions data={filteredOptions} />
+      ) : (
+        <ComboboxOptions data={rawData} />
+      )}
     </ComboboxField>
   );
 }

--- a/src/components/feature/field-mapper.tsx
+++ b/src/components/feature/field-mapper.tsx
@@ -7,6 +7,8 @@ import {
 import { useMemo, useState } from 'react';
 
 import { ComboboxField } from '@/components/form/combobox-field';
+import { ComboboxOptions } from '@/components/form/combobox-options';
+import { findFieldOption } from '@/lib/field-options';
 import { useFieldOptions, useSourcesForInput } from '@/lib/hooks';
 import { Label } from '../ui/label';
 import { CommandGroup } from '../ui/command';
@@ -44,12 +46,13 @@ export function FieldMapperField(props: Props) {
     });
 
   const selectedMainOption = useMemo(() => {
-    const flatResult = mainInputOptions.data.find(
-      (option) => option.value === props.value.mainInput,
+    const dataMatch = findFieldOption(
+      mainInputOptions.data,
+      props.value.mainInput,
     );
 
-    if (flatResult) {
-      return flatResult;
+    if (dataMatch) {
+      return dataMatch;
     }
 
     for (const group of mainInputOptions.nestedData ?? []) {
@@ -81,9 +84,7 @@ export function FieldMapperField(props: Props) {
 
   const selectedDependentInputOption = useMemo(
     () =>
-      dependentInputOptions?.data.find(
-        (option) => option.value === props.value.dependentInput,
-      ),
+      findFieldOption(dependentInputOptions?.data ?? [], props.value.dependentInput),
     [dependentInputOptions?.data, props.value],
   );
 
@@ -125,9 +126,7 @@ export function FieldMapperField(props: Props) {
     }
 
     for (const [key, value] of Object.entries(props.value.fieldMappings)) {
-      const option = fieldInputOptions.data.find(
-        (option) => option.value === value,
-      );
+      const option = findFieldOption(fieldInputOptions.data, value);
 
       if (!option) {
         continue;
@@ -170,11 +169,7 @@ export function FieldMapperField(props: Props) {
       ));
     }
 
-    return mainInputOptions.data.map((option) => (
-      <ComboboxField.Item key={option.value} value={option.value}>
-        {option.label}
-      </ComboboxField.Item>
-    ));
+    return <ComboboxOptions data={mainInputOptions.data} />;
   }
 
   return (
@@ -225,13 +220,7 @@ export function FieldMapperField(props: Props) {
             disabled={!props.value.mainInput}
             allowClear
           >
-            {dependentInputOptions.data.map((option) => {
-              return (
-                <ComboboxField.Item key={option.value} value={option.value}>
-                  {option.label}
-                </ComboboxField.Item>
-              );
-            })}
+            <ComboboxOptions data={dependentInputOptions.data} />
           </ComboboxField>
         )}
       </div>
@@ -265,13 +254,7 @@ export function FieldMapperField(props: Props) {
               )}
               allowClear
             >
-              {fieldInputOptions.data.map((option) => {
-                return (
-                  <ComboboxField.Item key={option.value} value={option.value}>
-                    {option.label}
-                  </ComboboxField.Item>
-                );
-              })}
+              <ComboboxOptions data={fieldInputOptions.data} />
             </ComboboxField>
             <MoveHorizontal className="h-4 w-4 shrink-0 opacity-50" />
             <Label>{fieldMap.label}</Label>

--- a/src/components/feature/integration/integration-list.tsx
+++ b/src/components/feature/integration/integration-list.tsx
@@ -6,8 +6,9 @@ import {
   paragon,
 } from '@useparagon/connect';
 
+import { Input } from '@/components/ui/input';
 import { IntegrationCard } from './integration-card';
-import { useEffect } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 export function IntegrationList() {
   const { data: user, refetch: refetchUser } = useAuthenticatedUser();
@@ -16,6 +17,7 @@ export function IntegrationList() {
     isLoading: isLoadingIntegrations,
     refetch: refetchIntegrations,
   } = useIntegrationMetadata();
+  const [searchQuery, setSearchQuery] = useState('');
 
   useEffect(() => {
     const updateUser = () => {
@@ -32,36 +34,66 @@ export function IntegrationList() {
     };
   }, [refetchUser, refetchIntegrations]);
 
+  const filteredIntegrations = useMemo(() => {
+    if (!integrations || !user) {
+      return [];
+    }
+
+    const sorted = [...integrations].sort(byEnabledOnTop(user));
+    const query = searchQuery.trim().toLowerCase();
+
+    if (!query) {
+      return sorted;
+    }
+
+    return sorted.filter(
+      (integration) =>
+        integration.name.toLowerCase().includes(query) ||
+        integration.type.toLowerCase().includes(query),
+    );
+  }, [integrations, user, searchQuery]);
+
   if (!user || isLoadingIntegrations || !integrations) {
     return <div>Loading...</div>;
   }
-
-  const sortedIntegrations = integrations.sort(byEnabledOnTop(user));
 
   return (
     <div className="flex flex-col gap-6">
       <div>
         <h2 className="text-xl font-medium mb-4">Integrations</h2>
-        <ul className="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-4 items-stretch">
-          {sortedIntegrations.map((integration) => {
-            const integrationInfo = user.integrations[integration.type];
+        <Input
+          type="search"
+          placeholder="Search integrations..."
+          value={searchQuery}
+          onChange={(event) => setSearchQuery(event.target.value)}
+          className="mb-4 max-w-sm"
+        />
+        {filteredIntegrations.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No integrations match your search.
+          </p>
+        ) : (
+          <ul className="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-4 items-stretch">
+            {filteredIntegrations.map((integration) => {
+              const integrationInfo = user.integrations[integration.type];
 
-            if (!integrationInfo) {
-              return null;
-            }
+              if (!integrationInfo) {
+                return null;
+              }
 
-            return (
-              <li key={integration.type} className="flex w-full">
-                <IntegrationCard
-                  type={integration.type}
-                  name={integration.name}
-                  icon={integration.icon}
-                  integrationInfo={integrationInfo}
-                />
-              </li>
-            );
-          })}
-        </ul>
+              return (
+                <li key={integration.type} className="flex w-full">
+                  <IntegrationCard
+                    type={integration.type}
+                    name={integration.name}
+                    icon={integration.icon}
+                    integrationInfo={integrationInfo}
+                  />
+                </li>
+              );
+            })}
+          </ul>
+        )}
       </div>
     </div>
   );

--- a/src/components/feature/integration/integration-modal/components/triggers.tsx
+++ b/src/components/feature/integration/integration-modal/components/triggers.tsx
@@ -1,0 +1,42 @@
+import { BellIcon, PlusIcon } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import {
+  TriggerSubscriptionModal,
+  type TriggerFormState,
+} from '@/components/feature/trigger/trigger-subscription-modal';
+
+export function TriggerSection(props: {
+  integration: string;
+  selectedCredentialId?: string;
+}) {
+  const handleSubmit = async (data: TriggerFormState) => {
+    console.log('Trigger subscription created:', data);
+  };
+
+  return (
+    <div className="flex flex-col items-center justify-center gap-4 py-12 text-center">
+      <div className="flex items-center justify-center w-12 h-12 rounded-full bg-muted">
+        <BellIcon className="size-6 text-muted-foreground" />
+      </div>
+      <div className="flex flex-col gap-1">
+        <p className="text-sm font-medium">No trigger subscriptions</p>
+        <p className="text-sm text-muted-foreground">
+          Subscribe to events from this integration to get notified when things
+          happen.
+        </p>
+      </div>
+      <TriggerSubscriptionModal
+        integration={props.integration}
+        selectedCredentialId={props.selectedCredentialId}
+        onSubmit={handleSubmit}
+        trigger={
+          <Button variant="outline" size="sm">
+            <PlusIcon />
+            New Subscription
+          </Button>
+        }
+      />
+    </div>
+  );
+}

--- a/src/components/feature/integration/integration-modal/components/triggers.tsx
+++ b/src/components/feature/integration/integration-modal/components/triggers.tsx
@@ -1,19 +1,12 @@
 import { BellIcon, PlusIcon } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
-import {
-  TriggerSubscriptionModal,
-  type TriggerFormState,
-} from '@/components/feature/trigger/trigger-subscription-modal';
+import { TriggerSubscriptionModal } from '@/components/feature/trigger/trigger-subscription-modal';
 
 export function TriggerSection(props: {
   integration: string;
   selectedCredentialId?: string;
 }) {
-  const handleSubmit = async (data: TriggerFormState) => {
-    console.log('Trigger subscription created:', data);
-  };
-
   return (
     <div className="flex flex-col items-center justify-center gap-4 py-12 text-center">
       <div className="flex items-center justify-center w-12 h-12 rounded-full bg-muted">
@@ -29,7 +22,6 @@ export function TriggerSection(props: {
       <TriggerSubscriptionModal
         integration={props.integration}
         selectedCredentialId={props.selectedCredentialId}
-        onSubmit={handleSubmit}
         trigger={
           <Button variant="outline" size="sm">
             <PlusIcon />

--- a/src/components/feature/integration/integration-modal/integration-modal.tsx
+++ b/src/components/feature/integration/integration-modal/integration-modal.tsx
@@ -22,6 +22,7 @@ import { IntegrationInstallFlowForm } from '@/components/feature/integration/int
 import { ActionButton } from './components/action-button';
 import { WorkflowSection } from './components/workflows';
 import { IntegrationSettingsSection } from './components/integration-settings';
+import { TriggerSection } from './components/triggers';
 import { ErrorMessage } from '../error-message';
 import { Button } from '@/components/ui/button';
 import { Time } from '@/lib/time';
@@ -220,7 +221,7 @@ export function IntegrationModal(props: Props) {
             </div>
           ) : (
             <Tabs value={tab} onValueChange={setTab} className="w-full">
-              <TabsList className="w-[250px] grid grid-cols-2">
+              <TabsList className="w-[375px] grid grid-cols-3">
                 <TabsTrigger className="cursor-pointer" value="overview">
                   Overview
                 </TabsTrigger>
@@ -230,6 +231,13 @@ export function IntegrationModal(props: Props) {
                   disabled={configurationTabDisabled}
                 >
                   Configuration
+                </TabsTrigger>
+                <TabsTrigger
+                  className="cursor-pointer"
+                  value="triggers"
+                  disabled={configurationTabDisabled}
+                >
+                  Triggers
                 </TabsTrigger>
               </TabsList>
               <TabsContent value="overview" className="w-full">
@@ -243,18 +251,28 @@ export function IntegrationModal(props: Props) {
                 </div>
               </TabsContent>
               {props.selectedCredentialId ? (
-                <TabsContent value="configuration" className="w-full">
-                  <div className="p-6 flex flex-col gap-6">
-                    <IntegrationSettingsSection
-                      integration={props.integration}
-                      selectedCredentialId={props.selectedCredentialId}
-                    />
-                    <WorkflowSection
-                      integration={props.integration}
-                      selectedCredentialId={props.selectedCredentialId}
-                    />
-                  </div>
-                </TabsContent>
+                <>
+                  <TabsContent value="configuration" className="w-full">
+                    <div className="p-6 flex flex-col gap-6">
+                      <IntegrationSettingsSection
+                        integration={props.integration}
+                        selectedCredentialId={props.selectedCredentialId}
+                      />
+                      <WorkflowSection
+                        integration={props.integration}
+                        selectedCredentialId={props.selectedCredentialId}
+                      />
+                    </div>
+                  </TabsContent>
+                  <TabsContent value="triggers" className="w-full">
+                    <div className="p-6">
+                      <TriggerSection
+                        integration={props.integration}
+                        selectedCredentialId={props.selectedCredentialId}
+                      />
+                    </div>
+                  </TabsContent>
+                </>
               ) : null}
             </Tabs>
           )}

--- a/src/components/feature/trigger/filter-records-input.tsx
+++ b/src/components/feature/trigger/filter-records-input.tsx
@@ -1,0 +1,390 @@
+import { useMemo, useState } from 'react';
+import { PlusIcon, XIcon } from 'lucide-react';
+import type { EnumInputValue } from '@useparagon/connect';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { ComboboxField } from '@/components/form/combobox-field';
+import { ComboboxOptions } from '@/components/form/combobox-options';
+import { FieldLabel } from '@/components/form/field-label';
+import {
+  type FieldOptionsData,
+  flattenFieldOptions,
+} from '@/lib/field-options';
+
+import { operatorHasArgument } from './filter-records-operators';
+import {
+  type ConditionalConfig,
+  type FilterCondition,
+  type FilterRecordsState,
+  type FilterValue,
+  useFilterRecordsState,
+} from './use-filter-records-state';
+
+// Radix `Select` warns when its `value` flips between `undefined` and a
+// defined string (controlled <-> uncontrolled). It also rejects `''` as a
+// valid item value, so we use this sentinel to keep the select controlled
+// while still rendering the placeholder when no operator is selected.
+const OPERATOR_PLACEHOLDER = '__operator_placeholder__';
+
+type Props = {
+  config: ConditionalConfig;
+  integration: string;
+  value: FilterValue;
+  onChange: (value: FilterValue) => void;
+};
+
+type FieldRenderConfig = {
+  options: FieldOptionsData;
+  disabled: boolean;
+  placeholder: string;
+  showCombo: boolean;
+  isLoading: boolean;
+};
+
+export function FilterRecordsInput({
+  config,
+  integration,
+  value,
+  onChange,
+}: Props) {
+  const state = useFilterRecordsState({ config, integration, value, onChange });
+
+  if (state.groups.length === 0) {
+    return (
+      <EmptyState
+        id={config.id}
+        title={config.title}
+        required={config.required ?? false}
+        onAddFirstGroup={state.addFirstGroup}
+      />
+    );
+  }
+
+  const fieldRenderConfig: FieldRenderConfig = {
+    options: state.fieldOptionsRaw,
+    disabled: state.fieldDisabled,
+    placeholder: state.fieldPlaceholder,
+    showCombo: state.showFieldCombo,
+    isLoading: state.isLoadingFields,
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      <FilterFieldLabel
+        id={config.id}
+        title={config.title}
+        required={config.required ?? false}
+      />
+      {state.groups.map((group, groupIndex) => (
+        <GroupSection
+          key={group.id}
+          group={group}
+          groupIndex={groupIndex}
+          isLast={groupIndex === state.groups.length - 1}
+          disableOrCondition={state.disableOrCondition}
+          fieldRenderConfig={fieldRenderConfig}
+          operatorItems={state.operatorItems}
+          onPatchCondition={state.patchCondition}
+          onRemoveCondition={state.removeCondition}
+          onAddAndCondition={state.addAndCondition}
+          onAddOrGroup={state.addOrGroup}
+        />
+      ))}
+    </div>
+  );
+}
+
+// -- Subcomponents -----------------------------------------------------------
+
+function FilterFieldLabel({
+  id,
+  title,
+  required,
+}: {
+  id: string;
+  title: string;
+  required: boolean;
+}) {
+  return (
+    <FieldLabel id={id} required={required}>
+      {title}
+      {!required && (
+        <span className="ml-1 text-xs font-normal text-muted-foreground">
+          (optional)
+        </span>
+      )}
+    </FieldLabel>
+  );
+}
+
+function EmptyState({
+  id,
+  title,
+  required,
+  onAddFirstGroup,
+}: {
+  id: string;
+  title: string;
+  required: boolean;
+  onAddFirstGroup: () => void;
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <FilterFieldLabel id={id} title={title} required={required} />
+      <div>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="text-muted-foreground hover:text-foreground -ml-2"
+          onClick={onAddFirstGroup}
+        >
+          <PlusIcon />
+          Add filter
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+type GroupSectionProps = {
+  group: { id: string; conditions: FilterCondition[] };
+  groupIndex: number;
+  isLast: boolean;
+  disableOrCondition: boolean;
+  fieldRenderConfig: FieldRenderConfig;
+  operatorItems: FilterRecordsState['operatorItems'];
+  onPatchCondition: FilterRecordsState['patchCondition'];
+  onRemoveCondition: FilterRecordsState['removeCondition'];
+  onAddAndCondition: FilterRecordsState['addAndCondition'];
+  onAddOrGroup: FilterRecordsState['addOrGroup'];
+};
+
+function GroupSection({
+  group,
+  groupIndex,
+  isLast,
+  disableOrCondition,
+  fieldRenderConfig,
+  operatorItems,
+  onPatchCondition,
+  onRemoveCondition,
+  onAddAndCondition,
+  onAddOrGroup,
+}: GroupSectionProps) {
+  return (
+    <div className="flex flex-col gap-2">
+      {groupIndex > 0 && <ConjunctionLabel>Or</ConjunctionLabel>}
+      {group.conditions.map((condition, condIndex) => (
+        <div key={condition.id} className="flex flex-col gap-1">
+          {condIndex > 0 && <ConjunctionLabel>And</ConjunctionLabel>}
+          <ConditionRow
+            condition={condition}
+            field={fieldRenderConfig}
+            operatorItems={operatorItems}
+            onPatch={(patch) => onPatchCondition(groupIndex, condIndex, patch)}
+            onRemove={() => onRemoveCondition(groupIndex, condIndex)}
+          />
+        </div>
+      ))}
+      <div className="flex gap-1">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="text-muted-foreground hover:text-foreground -ml-2"
+          onClick={() => onAddAndCondition(groupIndex)}
+        >
+          <PlusIcon />
+          And
+        </Button>
+        {!disableOrCondition && isLast && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-muted-foreground hover:text-foreground"
+            onClick={onAddOrGroup}
+          >
+            <PlusIcon />
+            Or
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ConjunctionLabel({ children }: { children: string }) {
+  return (
+    <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+      {children}
+    </span>
+  );
+}
+
+type ConditionRowProps = {
+  condition: FilterCondition;
+  field: FieldRenderConfig;
+  operatorItems: FilterRecordsState['operatorItems'];
+  onPatch: (patch: Partial<FilterCondition>) => void;
+  onRemove: () => void;
+};
+
+function ConditionRow({
+  condition,
+  field,
+  operatorItems,
+  onPatch,
+  onRemove,
+}: ConditionRowProps) {
+  const handleOperatorChange = (next: string) => {
+    const patch: Partial<FilterCondition> = { operator: next };
+    if (!operatorHasArgument(next)) {
+      patch.value = '';
+    }
+    onPatch(patch);
+  };
+
+  return (
+    <div className="flex items-start gap-2">
+      <div className="flex-1 min-w-0">
+        {field.showCombo ? (
+          <FieldComboBox
+            value={condition.field}
+            options={field.options}
+            placeholder={field.placeholder}
+            disabled={field.disabled}
+            isFetching={field.isLoading}
+            onSelect={(next) => onPatch({ field: next ?? '' })}
+          />
+        ) : (
+          <Input
+            value={condition.field}
+            onChange={(e) => onPatch({ field: e.target.value })}
+            placeholder={field.placeholder}
+            disabled={field.disabled}
+          />
+        )}
+      </div>
+
+      <div className="flex-1 min-w-0">
+        <Select
+          value={condition.operator || OPERATOR_PLACEHOLDER}
+          onValueChange={(next) =>
+            handleOperatorChange(next === OPERATOR_PLACEHOLDER ? '' : next)
+          }
+        >
+          <SelectTrigger
+            aria-label="Operator"
+            className="w-full"
+            disabled={operatorItems.length === 0}
+          >
+            <SelectValue placeholder="Select operator" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectGroup>
+              {operatorItems.map((item) => (
+                <SelectItem key={item.id} value={item.id}>
+                  {item.name}
+                </SelectItem>
+              ))}
+            </SelectGroup>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {operatorHasArgument(condition.operator) && (
+        <div className="flex-1 min-w-0">
+          <Input
+            value={condition.value}
+            onChange={(e) => onPatch({ value: e.target.value })}
+            placeholder="Value"
+          />
+        </div>
+      )}
+
+      <Button
+        variant="ghost"
+        size="icon-sm"
+        onClick={onRemove}
+        aria-label="Remove condition"
+        className="text-muted-foreground hover:text-destructive"
+      >
+        <XIcon />
+      </Button>
+    </div>
+  );
+}
+
+// -- Field combobox ----------------------------------------------------------
+
+function getEnumOptionLabel(item: EnumInputValue): string {
+  if (typeof item === 'string' || typeof item === 'number') return String(item);
+  return item.label ?? String(item.value);
+}
+
+function getEnumOptionValue(item: EnumInputValue): string {
+  if (typeof item === 'object') return String(item.value);
+  return String(item);
+}
+
+function FieldComboBox({
+  value,
+  options,
+  placeholder,
+  disabled,
+  isFetching,
+  onSelect,
+}: {
+  value: string;
+  options: FieldOptionsData;
+  placeholder: string;
+  disabled: boolean;
+  isFetching: boolean;
+  onSelect: (next: string | null) => void;
+}) {
+  const [search, setSearch] = useState('');
+
+  const flatOptions = useMemo(() => flattenFieldOptions(options), [options]);
+
+  // Client-side filtering. Dynamic-source results are typically small enough
+  // for this to be fine, and it matches the source component's behavior. When
+  // the user is actively searching we collapse sections into a flat result
+  // list; otherwise we preserve the grouped structure.
+  const renderData: FieldOptionsData = useMemo(() => {
+    if (!search) return options;
+    const needle = search.toLowerCase();
+    return flatOptions.filter((opt) =>
+      getEnumOptionLabel(opt).toLowerCase().includes(needle),
+    );
+  }, [options, flatOptions, search]);
+
+  const selectedLabel = useMemo(() => {
+    if (!value) return null;
+    const match = flatOptions.find((opt) => getEnumOptionValue(opt) === value);
+    return match ? getEnumOptionLabel(match) : value;
+  }, [flatOptions, value]);
+
+  return (
+    <ComboboxField
+      id="filter-field"
+      required={false}
+      value={value || null}
+      placeholder={selectedLabel ?? placeholder}
+      onSelect={onSelect}
+      onDebouncedChange={setSearch}
+      isFetching={isFetching}
+      disabled={disabled}
+      allowClear
+    >
+      <ComboboxOptions data={renderData} />
+    </ComboboxField>
+  );
+}

--- a/src/components/feature/trigger/filter-records-input.tsx
+++ b/src/components/feature/trigger/filter-records-input.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useId, useMemo, useState } from 'react';
 import { PlusIcon, XIcon } from 'lucide-react';
 import type { EnumInputValue } from '@useparagon/connect';
 
@@ -350,6 +350,7 @@ function FieldComboBox({
   isFetching: boolean;
   onSelect: (next: string | null) => void;
 }) {
+  const id = useId();
   const [search, setSearch] = useState('');
 
   const flatOptions = useMemo(() => flattenFieldOptions(options), [options]);
@@ -374,7 +375,7 @@ function FieldComboBox({
 
   return (
     <ComboboxField
-      id="filter-field"
+      id={id}
       required={false}
       value={value || null}
       placeholder={selectedLabel ?? placeholder}

--- a/src/components/feature/trigger/filter-records-operators.ts
+++ b/src/components/feature/trigger/filter-records-operators.ts
@@ -1,0 +1,54 @@
+import { Operator } from '@useparagon/connect';
+
+export const OPERATOR_LABELS: Record<string, string> = {
+  [Operator.StringContains]: 'contains',
+  [Operator.StringDoesNotContain]: 'does not contain',
+  [Operator.StringExactlyMatches]: 'exactly matches',
+  [Operator.StringDoesNotExactlyMatch]: 'does not exactly match',
+  [Operator.StringIsIn]: 'is in',
+  [Operator.StringIsNotIn]: 'is not in',
+  [Operator.StringStartsWith]: 'starts with',
+  [Operator.StringDoesNotStartWith]: 'does not start with',
+  [Operator.StringEndsWith]: 'ends with',
+  [Operator.StringDoesNotEndWith]: 'does not end with',
+  [Operator.StringGreaterThan]: 'greater than',
+  [Operator.StringLessThan]: 'less than',
+  [Operator.NumberGreaterThan]: 'greater than',
+  [Operator.NumberLessThan]: 'less than',
+  [Operator.NumberEquals]: 'equals',
+  [Operator.NumberDoesNotEqual]: 'does not equal',
+  [Operator.NumberLessThanOrEqualTo]: 'less than or equal to',
+  [Operator.NumberGreaterThanOrEqualTo]: 'greater than or equal to',
+  [Operator.DateTimeAfter]: 'after',
+  [Operator.DateTimeBefore]: 'before',
+  [Operator.DateTimeEquals]: 'date equals',
+  [Operator.BooleanTrue]: 'is true',
+  [Operator.BooleanFalse]: 'is false',
+  [Operator.IsNotNull]: 'is not null',
+  [Operator.IsNull]: 'is null',
+  [Operator.Exists]: 'exists',
+  [Operator.DoesNotExist]: 'does not exist',
+  [Operator.ArrayIsIn]: 'array contains',
+  [Operator.ArrayIsNotIn]: 'array does not contain',
+  [Operator.ArrayIsEmpty]: 'is empty',
+  [Operator.ArrayIsNotEmpty]: 'is not empty',
+};
+
+// The SDK does not export the OPERATORS metadata table, so we mirror it here:
+// these are the operators whose semantics are a unary check (no right-hand value).
+const OPERATORS_WITHOUT_ARGUMENT = new Set<string>([
+  Operator.None,
+  Operator.BooleanTrue,
+  Operator.BooleanFalse,
+  Operator.IsNotNull,
+  Operator.IsNull,
+  Operator.Exists,
+  Operator.DoesNotExist,
+  Operator.ArrayIsEmpty,
+  Operator.ArrayIsNotEmpty,
+]);
+
+export function operatorHasArgument(op: string): boolean {
+  if (!op) return false;
+  return !OPERATORS_WITHOUT_ARGUMENT.has(op);
+}

--- a/src/components/feature/trigger/trigger-form-context.tsx
+++ b/src/components/feature/trigger/trigger-form-context.tsx
@@ -46,8 +46,6 @@ export function TriggerFormProvider({ children }: { children: ReactNode }) {
     [parametersByKey, registerParameter, unregisterParameter],
   );
 
-  console.log('trigger form context', parametersByKey);
-
   return (
     <TriggerFormContext.Provider value={value}>
       {children}

--- a/src/components/feature/trigger/trigger-form-context.tsx
+++ b/src/components/feature/trigger/trigger-form-context.tsx
@@ -1,0 +1,66 @@
+import {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
+
+type ParametersByKey = Record<string, unknown>;
+
+type TriggerFormContextValue = {
+  /**
+   * Values of sibling trigger inputs, indexed by their `IntentInputKeyConfig.id`.
+   * This is the key space that `DynamicDataSource.refreshDependencies` entries
+   * reference.
+   */
+  parametersByKey: ParametersByKey;
+  registerParameter: (key: string, value: unknown) => void;
+  unregisterParameter: (key: string) => void;
+};
+
+const TriggerFormContext = createContext<TriggerFormContextValue | null>(null);
+
+export function TriggerFormProvider({ children }: { children: ReactNode }) {
+  const [parametersByKey, setParametersByKey] = useState<ParametersByKey>({});
+
+  const registerParameter = useCallback((key: string, value: unknown) => {
+    setParametersByKey((prev) => {
+      if (key in prev && Object.is(prev[key], value)) return prev;
+      return { ...prev, [key]: value };
+    });
+  }, []);
+
+  const unregisterParameter = useCallback((key: string) => {
+    setParametersByKey((prev) => {
+      if (!(key in prev)) return prev;
+      const next = { ...prev };
+      delete next[key];
+      return next;
+    });
+  }, []);
+
+  const value = useMemo<TriggerFormContextValue>(
+    () => ({ parametersByKey, registerParameter, unregisterParameter }),
+    [parametersByKey, registerParameter, unregisterParameter],
+  );
+
+  console.log('trigger form context', parametersByKey);
+
+  return (
+    <TriggerFormContext.Provider value={value}>
+      {children}
+    </TriggerFormContext.Provider>
+  );
+}
+
+export function useTriggerFormContext() {
+  const ctx = useContext(TriggerFormContext);
+  if (!ctx) {
+    throw new Error(
+      'useTriggerFormContext must be used inside <TriggerFormProvider>',
+    );
+  }
+  return ctx;
+}

--- a/src/components/feature/trigger/trigger-parameter-input.tsx
+++ b/src/components/feature/trigger/trigger-parameter-input.tsx
@@ -190,7 +190,14 @@ function SourcedTriggerParameterField(props: FieldProps) {
   }, [dependencyKey, props.value, registerParameter, unregisterParameter]);
 
   if (!triggerInputSource || triggerInputSource.kind !== 'single') {
-    return null;
+    return (
+      <TriggerParameterInput
+        integration={props.integration}
+        config={props.param}
+        value={props.value}
+        onChange={props.onChange}
+      />
+    );
   }
 
   const { source } = triggerInputSource as SingleSource;

--- a/src/components/feature/trigger/trigger-parameter-input.tsx
+++ b/src/components/feature/trigger/trigger-parameter-input.tsx
@@ -1,0 +1,335 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  SidebarInputType,
+  DataSourceType,
+  type ConnectInputValue,
+  type IntentInputKeyConfig,
+  type GraphiteEnumInput,
+  type SerializedConnectInput,
+  type DynamicDataSource,
+  type StaticEnumDataSource,
+  type SingleSource,
+  type EnumInputValue,
+} from '@useparagon/connect';
+
+import { SerializedConnectInputPicker } from '../serialized-connect-input-picker';
+import { TextInputField } from '../../form/text-input-field';
+import { SelectField } from '../../form/select-field';
+import { FieldLabel } from '../../form/field-label';
+import { Textarea } from '../../ui/textarea';
+import { cn } from '@/lib/utils';
+import { ComboboxField } from '@/components/form/combobox-field';
+import { ComboboxOptions } from '@/components/form/combobox-options';
+import { findFieldOption } from '@/lib/field-options';
+import { useFieldOptions, useSourcesForTriggerInput } from '@/lib/hooks';
+import { useTriggerFormContext } from './trigger-form-context';
+import { FilterRecordsInput } from './filter-records-input';
+import type {
+  ConditionalConfig,
+  FilterValue,
+} from './use-filter-records-state';
+
+type Props = {
+  integration: string;
+  config: IntentInputKeyConfig;
+  value: unknown;
+  onChange: (value: unknown) => void;
+};
+
+const PROXY_TYPES = new Set<string>([
+  SidebarInputType.Switch,
+  SidebarInputType.BooleanInput,
+  SidebarInputType.ValueText,
+  SidebarInputType.Password,
+  SidebarInputType.Number,
+]);
+
+function toSerializedConnectInput(
+  config: IntentInputKeyConfig,
+): SerializedConnectInput {
+  return {
+    id: config.id,
+    title: config.title,
+    type: config.type,
+    required: config.required,
+    tooltip: config.subtitle,
+  } as SerializedConnectInput;
+}
+
+function getEnumLabel(item: GraphiteEnumInput): string {
+  if (typeof item === 'string') return item;
+  if (typeof item === 'number') return String(item);
+  return item.label ?? String(item.value);
+}
+
+function getEnumValue(item: GraphiteEnumInput): string {
+  if (typeof item === 'object') return String(item.value);
+  return String(item);
+}
+
+export function TriggerParameterInput({
+  integration,
+  config,
+  value,
+  onChange,
+}: Props) {
+  const required = config.required ?? false;
+
+  if (PROXY_TYPES.has(config.type)) {
+    return (
+      <SerializedConnectInputPicker
+        integration={integration}
+        field={toSerializedConnectInput(config)}
+        value={value as ConnectInputValue}
+        onChange={onChange}
+      />
+    );
+  }
+
+  if (
+    config.type === SidebarInputType.Enum ||
+    config.type === SidebarInputType.EditableEnum ||
+    config.type === SidebarInputType.EnumTextAreaPairInput
+  ) {
+    const values = 'values' in config ? config.values : [];
+    return (
+      <SelectField
+        id={config.id}
+        title={config.title}
+        required={required}
+        value={(value as string) ?? null}
+        onChange={(v) => onChange(v ?? undefined)}
+      >
+        {values.map((item) => (
+          <SelectField.Item key={getEnumValue(item)} value={getEnumValue(item)}>
+            {getEnumLabel(item)}
+          </SelectField.Item>
+        ))}
+      </SelectField>
+    );
+  }
+
+  if (
+    config.type === SidebarInputType.Text ||
+    config.type === SidebarInputType.Code
+  ) {
+    return (
+      <TextInputField
+        type="text"
+        id={config.id}
+        title={config.title}
+        subtitle={config.subtitle}
+        required={required}
+        value={String(value ?? '')}
+        onChange={onChange}
+        className={cn(config.type === SidebarInputType.Code && 'font-mono')}
+        placeholder={config.placeholder}
+      />
+    );
+  }
+
+  if (config.type === SidebarInputType.TextArea) {
+    return (
+      <div className="flex flex-col gap-1.5 w-full">
+        <FieldLabel id={config.id} required={required}>
+          {config.title}
+        </FieldLabel>
+        {config.subtitle && (
+          <p className="text-sm text-gray-500">{config.subtitle}</p>
+        )}
+        <Textarea
+          id={config.id}
+          value={String(value ?? '')}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={config.placeholder}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <p>Field not supported:</p>
+      <pre className="max-w-full max-h-[150px] text-sm overflow-auto bg-card p-2 rounded-md border border-border">
+        {JSON.stringify(config, null, 2)}
+      </pre>
+    </div>
+  );
+}
+
+type FieldProps = {
+  integration: string;
+  param: IntentInputKeyConfig;
+  value: unknown;
+  onChange: (value: unknown) => void;
+};
+
+export function TriggerParameterField(props: FieldProps) {
+  if (props.param.type === SidebarInputType.Conditional) {
+    return (
+      <FilterRecordsInput
+        config={props.param as ConditionalConfig}
+        integration={props.integration}
+        value={(props.value as FilterValue | undefined) ?? []}
+        onChange={(next) => props.onChange(next)}
+      />
+    );
+  }
+
+  return <SourcedTriggerParameterField {...props} />;
+}
+
+function SourcedTriggerParameterField(props: FieldProps) {
+  const triggerInputSource = useSourcesForTriggerInput(props.param);
+  const { registerParameter, unregisterParameter } = useTriggerFormContext();
+  const dependencyKey = props.param.id;
+
+  useEffect(() => {
+    registerParameter(dependencyKey, props.value);
+    return () => unregisterParameter(dependencyKey);
+  }, [dependencyKey, props.value, registerParameter, unregisterParameter]);
+
+  if (!triggerInputSource || triggerInputSource.kind !== 'single') {
+    return null;
+  }
+
+  const { source } = triggerInputSource as SingleSource;
+
+  if (source.type === DataSourceType.STATIC_ENUM) {
+    return (
+      <StaticEnumTriggerParameterField
+        param={props.param}
+        source={source as StaticEnumDataSource}
+        value={props.value}
+        onChange={props.onChange}
+      />
+    );
+  }
+
+  if (source.type === DataSourceType.DYNAMIC) {
+    return (
+      <DynamicTriggerParameterField
+        integration={props.integration}
+        param={props.param}
+        source={source as DynamicDataSource<unknown>}
+        value={props.value}
+        onChange={props.onChange}
+      />
+    );
+  }
+
+  return null;
+}
+
+function StaticEnumTriggerParameterField({
+  param,
+  source,
+  value,
+  onChange,
+}: {
+  param: IntentInputKeyConfig;
+  source: StaticEnumDataSource;
+  value: unknown;
+  onChange: (value: unknown) => void;
+}) {
+  const flatOptions = useMemo<EnumInputValue[]>(() => {
+    if (!Array.isArray(source.values)) return [];
+    return source.values.flatMap((item) =>
+      item && typeof item === 'object' && 'items' in item ? item.items : [item],
+    );
+  }, [source.values]);
+
+  return (
+    <SelectField
+      id={param.id}
+      title={param.title}
+      required={param.required ?? false}
+      value={(value as string) ?? null}
+      onChange={(v) => onChange(v ?? undefined)}
+      allowClear
+    >
+      {flatOptions.map((option) => (
+        <SelectField.Item
+          key={String(option.value)}
+          value={String(option.value)}
+        >
+          {option.label}
+        </SelectField.Item>
+      ))}
+    </SelectField>
+  );
+}
+
+function DynamicTriggerParameterField({
+  integration,
+  param,
+  source,
+  value,
+  onChange,
+}: {
+  integration: string;
+  param: IntentInputKeyConfig;
+  source: DynamicDataSource<unknown>;
+  value: unknown;
+  onChange: (value: unknown) => void;
+}) {
+  const { parametersByKey } = useTriggerFormContext();
+  const [search, setSearch] = useState('');
+
+  const stringDependencyKeys = useMemo(
+    () =>
+      (source.refreshDependencies ?? []).filter(
+        (dep): dep is string => typeof dep === 'string',
+      ),
+    [source.refreshDependencies],
+  );
+
+  const dependencyParameters = useMemo(
+    () =>
+      stringDependencyKeys.map((key) => ({
+        cacheKey: key,
+        value: parametersByKey[key] as string | undefined,
+      })),
+    [stringDependencyKeys, parametersByKey],
+  );
+
+  // `refreshDependencies === undefined` means "only refresh on manual invoke"
+  // per the SDK. We treat that as "never auto-fetch" for now.
+  const noDependencies =
+    source.refreshDependencies === undefined ||
+    source.refreshDependencies.length === 0;
+  const allDependenciesSatisfied = dependencyParameters.every((p) =>
+    Boolean(p.value),
+  );
+  const enabled = noDependencies || allDependenciesSatisfied;
+
+  const { data, isFetching } = useFieldOptions({
+    integration,
+    source,
+    parameters: dependencyParameters,
+    search,
+    enabled,
+  });
+
+  const selectedOption = useMemo(
+    () => findFieldOption(data.data, value),
+    [data.data, value],
+  );
+
+  return (
+    <ComboboxField
+      id={param.id}
+      title={param.title}
+      required={param.required ?? false}
+      value={(value as string) ?? null}
+      placeholder={selectedOption?.label ?? 'Select an option...'}
+      onSelect={(next) => onChange(next ?? undefined)}
+      onDebouncedChange={setSearch}
+      isFetching={isFetching}
+      disabled={!enabled}
+      allowClear
+    >
+      <ComboboxOptions data={data.data} />
+    </ComboboxField>
+  );
+}

--- a/src/components/feature/trigger/trigger-subscription-modal.tsx
+++ b/src/components/feature/trigger/trigger-subscription-modal.tsx
@@ -1,0 +1,176 @@
+import { ReactNode, useCallback, useMemo, useReducer, useState } from 'react';
+import type { TriggerDefinition } from '@useparagon/connect';
+
+import { useTriggerTypes } from '@/lib/hooks';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { SelectField } from '@/components/form/select-field';
+import { TriggerParameterField } from './trigger-parameter-input';
+import { TriggerFormProvider } from './trigger-form-context';
+
+// -- Reducer ------------------------------------------------------------------
+
+export type TriggerFormState = {
+  triggerType: string | null;
+  parameters: Record<string, unknown>;
+};
+
+type FormAction =
+  | { type: 'SET_TRIGGER_TYPE'; payload: string }
+  | { type: 'SET_PARAMETER'; payload: { key: string; value: unknown } }
+  | { type: 'RESET'; payload?: TriggerFormState };
+
+const EMPTY_STATE: TriggerFormState = { triggerType: null, parameters: {} };
+
+function formReducer(
+  state: TriggerFormState,
+  action: FormAction,
+): TriggerFormState {
+  switch (action.type) {
+    case 'SET_TRIGGER_TYPE':
+      return { triggerType: action.payload, parameters: {} };
+    case 'SET_PARAMETER':
+      return {
+        ...state,
+        parameters: {
+          ...state.parameters,
+          [action.payload.key]: action.payload.value,
+        },
+      };
+    case 'RESET':
+      return action.payload ?? EMPTY_STATE;
+  }
+}
+
+// -- Modal --------------------------------------------------------------------
+
+type Props = {
+  integration: string;
+  selectedCredentialId?: string;
+  onSubmit: (data: TriggerFormState) => Promise<void>;
+  trigger: ReactNode;
+  initialData?: TriggerFormState;
+};
+
+export function TriggerSubscriptionModal({
+  integration,
+  selectedCredentialId,
+  trigger,
+  initialData,
+}: Props) {
+  const isEditMode = !!initialData;
+  const [open, setOpen] = useState(false);
+  const [state, dispatch] = useReducer(formReducer, initialData ?? EMPTY_STATE);
+
+  const { data: triggerTypes, isLoading } = useTriggerTypes(
+    integration,
+    selectedCredentialId ?? '',
+  );
+
+  const triggerDefinitions = useMemo<TriggerDefinition[]>(() => {
+    if (!triggerTypes?.triggers) return [];
+    return Object.values(triggerTypes.triggers).flat();
+  }, [triggerTypes]);
+
+  const selectedTrigger = useMemo(
+    () => triggerDefinitions.find((t) => t.type === state.triggerType),
+    [triggerDefinitions, state.triggerType],
+  );
+
+  const canSubmit = useMemo(() => {
+    if (!state.triggerType || !selectedTrigger) return false;
+    if (!selectedTrigger.parameters?.length) return true;
+    return selectedTrigger.parameters.every(
+      (p) => !p.required || !!state.parameters[p.id],
+    );
+  }, [state, selectedTrigger]);
+
+  const handleSubmit = useCallback(async () => {
+    if (!canSubmit) return;
+    console.log('state', state);
+  }, [canSubmit, state]);
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      setOpen(nextOpen);
+      if (!nextOpen) {
+        dispatch({ type: 'RESET', payload: initialData });
+      }
+    },
+    [initialData],
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>{trigger}</DialogTrigger>
+      <DialogContent className="w-[90dvw] max-w-[700px] min-h-[700px] flex flex-col">
+        <DialogHeader>
+          <DialogTitle>
+            {isEditMode
+              ? 'Edit Trigger Subscription'
+              : 'New Trigger Subscription'}
+          </DialogTitle>
+          <DialogDescription>
+            {isEditMode
+              ? 'Update the parameters for this trigger subscription.'
+              : 'Select a trigger type and configure its parameters.'}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4 py-4 flex-1">
+          <SelectField
+            id="trigger-type"
+            title="Trigger type"
+            required
+            disabled={isLoading || triggerDefinitions.length === 0}
+            value={state.triggerType}
+            onChange={(value) => {
+              if (value) dispatch({ type: 'SET_TRIGGER_TYPE', payload: value });
+            }}
+          >
+            {triggerDefinitions.map((def) => (
+              <SelectField.Item key={def.type} value={def.type}>
+                {def.title}
+              </SelectField.Item>
+            ))}
+          </SelectField>
+
+          <TriggerFormProvider>
+            {selectedTrigger?.parameters?.map((param) => (
+              <TriggerParameterField
+                key={param.id}
+                integration={integration}
+                param={param}
+                value={state.parameters[param.id]}
+                onChange={(value) =>
+                  dispatch({
+                    type: 'SET_PARAMETER',
+                    payload: { key: param.id, value },
+                  })
+                }
+              />
+            ))}
+          </TriggerFormProvider>
+        </div>
+
+        <DialogFooter className="mt-auto">
+          <DialogClose asChild>
+            <Button variant="outline">Cancel</Button>
+          </DialogClose>
+          <Button onClick={handleSubmit} disabled={!canSubmit}>
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/feature/trigger/trigger-subscription-modal.tsx
+++ b/src/components/feature/trigger/trigger-subscription-modal.tsx
@@ -56,7 +56,6 @@ function formReducer(
 type Props = {
   integration: string;
   selectedCredentialId?: string;
-  onSubmit: (data: TriggerFormState) => Promise<void>;
   trigger: ReactNode;
   initialData?: TriggerFormState;
 };
@@ -73,7 +72,7 @@ export function TriggerSubscriptionModal({
 
   const { data: triggerTypes, isLoading } = useTriggerTypes(
     integration,
-    selectedCredentialId ?? '',
+    selectedCredentialId,
   );
 
   const triggerDefinitions = useMemo<TriggerDefinition[]>(() => {
@@ -85,6 +84,9 @@ export function TriggerSubscriptionModal({
     () => triggerDefinitions.find((t) => t.type === state.triggerType),
     [triggerDefinitions, state.triggerType],
   );
+
+  /**
+   * NOTE: Can be used when implementing the submit functionality.
 
   const canSubmit = useMemo(() => {
     if (!state.triggerType || !selectedTrigger) return false;
@@ -98,6 +100,8 @@ export function TriggerSubscriptionModal({
     if (!canSubmit) return;
     console.log('state', state);
   }, [canSubmit, state]);
+
+  */
 
   const handleOpenChange = useCallback(
     (nextOpen: boolean) => {
@@ -166,9 +170,6 @@ export function TriggerSubscriptionModal({
           <DialogClose asChild>
             <Button variant="outline">Cancel</Button>
           </DialogClose>
-          <Button onClick={handleSubmit} disabled={!canSubmit}>
-            Save
-          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/src/components/feature/trigger/use-filter-records-state.ts
+++ b/src/components/feature/trigger/use-filter-records-state.ts
@@ -1,0 +1,296 @@
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import {
+  Operator,
+  SidebarInputType,
+  type EnumInputValue,
+  type IntentInputKeyConfig,
+} from '@useparagon/connect';
+
+import {
+  type FieldOptionsData,
+  flattenFieldOptions,
+} from '@/lib/field-options';
+import { useFieldOptions } from '@/lib/hooks';
+import { OPERATOR_LABELS } from './filter-records-operators';
+import { useTriggerFormContext } from './trigger-form-context';
+
+export type ConditionalConfig = Extract<
+  IntentInputKeyConfig,
+  { type: `${SidebarInputType.Conditional}` }
+>;
+
+export type FilterCondition = {
+  id: string;
+  field: string;
+  operator: string;
+  value: string;
+};
+
+export type ConditionGroup = {
+  id: string;
+  conjunction: 'AND' | 'OR';
+  conditions: FilterCondition[];
+};
+
+export type FilterValue = ConditionGroup[];
+
+export type UseFilterRecordsStateArgs = {
+  config: ConditionalConfig;
+  integration: string;
+  value: FilterValue;
+  onChange: (next: FilterValue) => void;
+};
+
+export type FilterRecordsState = {
+  groups: FilterValue;
+  fieldOptions: EnumInputValue[];
+  fieldOptionsRaw: FieldOptionsData;
+  operatorItems: Array<{ id: string; name: string }>;
+  showFieldCombo: boolean;
+  fieldDisabled: boolean;
+  fieldPlaceholder: string;
+  isLoadingFields: boolean;
+  disableOrCondition: boolean;
+  addFirstGroup: () => void;
+  addAndCondition: (groupIndex: number) => void;
+  addOrGroup: () => void;
+  patchCondition: (
+    groupIndex: number,
+    conditionIndex: number,
+    patch: Partial<FilterCondition>,
+  ) => void;
+  removeCondition: (groupIndex: number, conditionIndex: number) => void;
+};
+
+function createId(): string {
+  return crypto.randomUUID();
+}
+
+function createEmptyCondition(): FilterCondition {
+  return { id: createId(), field: '', operator: '', value: '' };
+}
+
+function createEmptyGroup(conjunction: 'AND' | 'OR'): ConditionGroup {
+  return {
+    id: createId(),
+    conjunction,
+    conditions: [createEmptyCondition()],
+  };
+}
+
+function getEnumOptionValue(item: EnumInputValue): string {
+  if (typeof item === 'object') return String(item.value);
+  return String(item);
+}
+
+export function useFilterRecordsState({
+  config,
+  integration,
+  value,
+  onChange,
+}: UseFilterRecordsStateArgs): FilterRecordsState {
+  const { parametersByKey } = useTriggerFormContext();
+
+  const supportedOperators = config.supportedOperators ?? [];
+  const supportedKeys = config.supportedKeys ?? [];
+  const disableOrCondition = config.disableOrCondition ?? false;
+  const keysSource = config.supportedKeysSource;
+  const keysDeps = useMemo(
+    () => keysSource?.dependencies ?? [],
+    [keysSource?.dependencies],
+  );
+
+  const groups: FilterValue = value ?? [];
+
+  const isDynamic = Boolean(keysSource?.sourceType);
+  const dependencyParameters = useMemo(
+    () =>
+      keysDeps.map((key) => ({
+        cacheKey: key,
+        value: parametersByKey[key] as string | undefined,
+      })),
+    [keysDeps, parametersByKey],
+  );
+  const depsSatisfied = dependencyParameters.every((p) => Boolean(p.value));
+  const enabled = isDynamic && (keysDeps.length === 0 || depsSatisfied);
+
+  const { data: dynamicData, isFetching: isLoadingFields } = useFieldOptions({
+    integration,
+    sourceType: keysSource?.sourceType,
+    parameters: dependencyParameters,
+    enabled,
+  });
+
+  const staticFieldOptions: EnumInputValue[] = useMemo(
+    () => supportedKeys.map((k) => ({ value: k, label: k })),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [supportedKeys.join(',')],
+  );
+
+  const fieldOptionsRaw: FieldOptionsData = useMemo(() => {
+    if (isDynamic) return dynamicData.data;
+    return staticFieldOptions;
+  }, [isDynamic, dynamicData.data, staticFieldOptions]);
+
+  const fieldOptions: EnumInputValue[] = useMemo(
+    () => flattenFieldOptions(fieldOptionsRaw),
+    [fieldOptionsRaw],
+  );
+
+  const showFieldCombo = isDynamic || staticFieldOptions.length > 0;
+
+  const updateGroups = useCallback(
+    (newGroups: FilterValue) => {
+      onChange(newGroups);
+    },
+    [onChange],
+  );
+
+  // Reset value when dynamic-source dependencies change. We compare a stable
+  // fingerprint string to avoid resetting on the initial mount.
+  const depsFingerprint = useMemo(() => {
+    if (keysDeps.length === 0) return '';
+    return keysDeps
+      .map((d) => `${d}:${JSON.stringify(parametersByKey[d] ?? null)}`)
+      .join('|');
+  }, [keysDeps, parametersByKey]);
+
+  const prevDepsFingerprintRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (prevDepsFingerprintRef.current === null) {
+      prevDepsFingerprintRef.current = depsFingerprint;
+      return;
+    }
+    if (prevDepsFingerprintRef.current === depsFingerprint) return;
+    prevDepsFingerprintRef.current = depsFingerprint;
+    if (groups.length > 0) {
+      updateGroups([]);
+    }
+  }, [depsFingerprint, groups.length, updateGroups]);
+
+  // When the available field set changes, drop any selected `field` values
+  // that are no longer valid options.
+  const optionValueSet = useMemo(
+    () => new Set(fieldOptions.map(getEnumOptionValue)),
+    [fieldOptions],
+  );
+
+  useEffect(() => {
+    if (!showFieldCombo) return;
+    if (isDynamic && isLoadingFields) return;
+    if (fieldOptions.length === 0) return;
+
+    let changed = false;
+    const next = groups.map((group) => ({
+      ...group,
+      conditions: group.conditions.map((cond) => {
+        if (!cond.field || optionValueSet.has(cond.field)) return cond;
+        changed = true;
+        return { ...cond, field: '' };
+      }),
+    }));
+
+    if (changed) updateGroups(next);
+  }, [
+    showFieldCombo,
+    isDynamic,
+    isLoadingFields,
+    fieldOptions.length,
+    optionValueSet,
+    groups,
+    updateGroups,
+  ]);
+
+  const operatorItems = useMemo(
+    () =>
+      supportedOperators
+        .filter((op) => op !== Operator.None)
+        .map((op) => ({ id: op, name: OPERATOR_LABELS[op] ?? op })),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [supportedOperators.join(',')],
+  );
+
+  const fieldDisabled = Boolean(keysDeps.length) && !depsSatisfied;
+  const fieldPlaceholder = fieldDisabled
+    ? 'Select dependencies first'
+    : isDynamic && isLoadingFields
+      ? 'Loading fields...'
+      : 'Select a field';
+
+  const addFirstGroup = useCallback(() => {
+    updateGroups([createEmptyGroup('AND')]);
+  }, [updateGroups]);
+
+  const addAndCondition = useCallback(
+    (groupIndex: number) => {
+      const updated = groups.map((group, i) => {
+        if (i !== groupIndex) return group;
+        return {
+          ...group,
+          conditions: [...group.conditions, createEmptyCondition()],
+        };
+      });
+      updateGroups(updated);
+    },
+    [groups, updateGroups],
+  );
+
+  const addOrGroup = useCallback(() => {
+    updateGroups([...groups, createEmptyGroup('OR')]);
+  }, [groups, updateGroups]);
+
+  const patchCondition = useCallback(
+    (
+      groupIndex: number,
+      conditionIndex: number,
+      patch: Partial<FilterCondition>,
+    ) => {
+      const updated = groups.map((group, gi) => {
+        if (gi !== groupIndex) return group;
+        return {
+          ...group,
+          conditions: group.conditions.map((cond, ci) => {
+            if (ci !== conditionIndex) return cond;
+            return { ...cond, ...patch };
+          }),
+        };
+      });
+      updateGroups(updated);
+    },
+    [groups, updateGroups],
+  );
+
+  const removeCondition = useCallback(
+    (groupIndex: number, conditionIndex: number) => {
+      let updated = groups.map((group, gi) => {
+        if (gi !== groupIndex) return group;
+        return {
+          ...group,
+          conditions: group.conditions.filter(
+            (_, ci) => ci !== conditionIndex,
+          ),
+        };
+      });
+      updated = updated.filter((group) => group.conditions.length > 0);
+      updateGroups(updated);
+    },
+    [groups, updateGroups],
+  );
+
+  return {
+    groups,
+    fieldOptions,
+    fieldOptionsRaw,
+    operatorItems,
+    showFieldCombo,
+    fieldDisabled,
+    fieldPlaceholder,
+    isLoadingFields: enabled && isLoadingFields,
+    disableOrCondition,
+    addFirstGroup,
+    addAndCondition,
+    addOrGroup,
+    patchCondition,
+    removeCondition,
+  };
+}

--- a/src/components/form/combobox-options.tsx
+++ b/src/components/form/combobox-options.tsx
@@ -1,0 +1,42 @@
+import type { EnumInputValue } from '@useparagon/connect';
+
+import { CommandGroup } from '@/components/ui/command';
+import { ComboboxField } from '@/components/form/combobox-field';
+import {
+  type FieldOptionsData,
+  getFieldOptionSections,
+} from '@/lib/field-options';
+
+type Props = {
+  data: FieldOptionsData;
+};
+
+/**
+ * Renders combobox items either as a flat list of `<ComboboxField.Item>`s
+ * or, when `data` contains `EnumSection`s, as labelled `<CommandGroup>`s.
+ */
+export function ComboboxOptions({ data }: Props) {
+  const sections = getFieldOptionSections(data);
+
+  if (sections) {
+    return (
+      <>
+        {sections.map((section) => (
+          <CommandGroup key={section.title} heading={section.title}>
+            {section.items.map(renderItem)}
+          </CommandGroup>
+        ))}
+      </>
+    );
+  }
+
+  return <>{(data as EnumInputValue[]).map(renderItem)}</>;
+}
+
+function renderItem(option: EnumInputValue) {
+  return (
+    <ComboboxField.Item key={String(option.value)} value={String(option.value)}>
+      {option.label}
+    </ComboboxField.Item>
+  );
+}

--- a/src/components/form/paginated-combobox.tsx
+++ b/src/components/form/paginated-combobox.tsx
@@ -4,6 +4,8 @@ import { useEffect, useMemo } from 'react';
 import { useInView } from 'react-intersection-observer';
 
 import { ComboboxField } from '@/components/form/combobox-field';
+import { ComboboxOptions } from '@/components/form/combobox-options';
+import { findFieldOption } from '@/lib/field-options';
 import { useFieldOptions, useInfiniteFieldOptions } from '@/lib/hooks';
 
 export type ComboDropdownProps = {
@@ -98,7 +100,7 @@ export function StaticComboDropdown(props: ComboDropdownProps) {
   });
 
   const selectedOption = useMemo(
-    () => options.data.find((option) => option.value === props.value),
+    () => findFieldOption(options.data, props.value),
     [options.data, props.value],
   );
 
@@ -115,11 +117,7 @@ export function StaticComboDropdown(props: ComboDropdownProps) {
       disabled={props.disabled}
       allowClear={props.allowClear}
     >
-      {options.data.map((option) => (
-        <ComboboxField.Item key={option.value} value={option.value}>
-          {option.label}
-        </ComboboxField.Item>
-      ))}
+      <ComboboxOptions data={options.data} />
     </ComboboxField>
   );
 }

--- a/src/components/form/select-field.tsx
+++ b/src/components/form/select-field.tsx
@@ -25,6 +25,7 @@ type BaseProps = {
   value: string | null;
   onChange: (value: string | null) => void;
   allowClear?: boolean;
+  disabled?: boolean;
 };
 
 type FlatProps = BaseProps & {
@@ -46,7 +47,7 @@ export function SelectField(props: Props) {
         {props.title}
       </FieldLabel>
       <div className="flex gap-2">
-        <Select value={props.value ?? ''} onValueChange={props.onChange}>
+        <Select value={props.value ?? ''} onValueChange={props.onChange} disabled={props.disabled}>
           <SelectTrigger className="w-[180px]" id={props.id}>
             <SelectValue placeholder="Select an item" />
           </SelectTrigger>

--- a/src/components/form/text-input-field.tsx
+++ b/src/components/form/text-input-field.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from 'react';
 
 import { Input } from '@/components/ui/input';
 import { FieldLabel } from './field-label';
+import { cn } from '@/lib/utils';
 
 type Props = {
   id: string;
@@ -15,7 +16,37 @@ type Props = {
   disabled?: boolean;
   readOnly?: boolean;
   className?: string;
+  placeholder?: string;
 };
+
+const LINK_PATTERN = /^(.*?)\((https?:\/\/[^)]+)\)(.*)$/;
+
+function Subtitle({ children }: { children: ReactNode }) {
+  if (typeof children !== 'string') {
+    return <p className="text-sm text-muted-foreground">{children}</p>;
+  }
+
+  const match = children.match(LINK_PATTERN);
+  if (!match) {
+    return <p className="text-sm text-muted-foreground">{children}</p>;
+  }
+
+  const [, before, url, after] = match;
+  return (
+    <p className="text-sm text-muted-foreground">
+      {before}
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-primary underline underline-offset-2"
+      >
+        🔗
+      </a>
+      {after}
+    </p>
+  );
+}
 
 export function TextInputField(props: Props) {
   return (
@@ -27,9 +58,7 @@ export function TextInputField(props: Props) {
       >
         {props.title}
       </FieldLabel>
-      {props.subtitle ? (
-        <p className="text-sm text-gray-500">{props.subtitle}</p>
-      ) : null}
+      {props.subtitle ? <Subtitle>{props.subtitle}</Subtitle> : null}
       <Input
         id={props.id}
         type={props.type}
@@ -37,6 +66,8 @@ export function TextInputField(props: Props) {
         onChange={(e) => props.onChange(e.target.value)}
         disabled={props.disabled}
         readOnly={props.readOnly}
+        className={cn(props.className, 'placeholder:text-muted-foreground/30')}
+        placeholder={props.placeholder}
       />
     </div>
   );

--- a/src/lib/field-options.ts
+++ b/src/lib/field-options.ts
@@ -1,0 +1,38 @@
+import type { EnumInputValue, EnumSection } from '@useparagon/connect';
+
+export type FieldOptionsData = EnumInputValue[] | EnumSection[];
+
+export function isEnumSection(
+  item: EnumInputValue | EnumSection,
+): item is EnumSection {
+  return (
+    typeof item === 'object' &&
+    item !== null &&
+    'items' in item &&
+    'title' in item &&
+    Array.isArray((item as EnumSection).items)
+  );
+}
+
+export function flattenFieldOptions(data: FieldOptionsData): EnumInputValue[] {
+  return data.flatMap((entry) => (isEnumSection(entry) ? entry.items : [entry]));
+}
+
+/**
+ * Returns the section list when `data` is grouped, otherwise `null`.
+ * Callers can use this to decide between rendering with `<CommandGroup>`
+ * headings and rendering a flat list.
+ */
+export function getFieldOptionSections(
+  data: FieldOptionsData,
+): EnumSection[] | null {
+  if (data.length === 0) return null;
+  return data.every(isEnumSection) ? (data as EnumSection[]) : null;
+}
+
+export function findFieldOption(
+  data: FieldOptionsData,
+  value: unknown,
+): EnumInputValue | undefined {
+  return flattenFieldOptions(data).find((option) => option.value === value);
+}

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -1,10 +1,13 @@
 import { useMemo } from 'react';
 import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import {
+  IntentInputKeyConfig,
   paragon,
   type DynamicDataSource,
   type SerializedConnectInput,
 } from '@useparagon/connect';
+
+import { flattenFieldOptions } from './field-options';
 
 export function useIntegrationMetadata() {
   return useQuery({
@@ -66,6 +69,10 @@ export function useSourcesForInput(
         : null,
     [integration, input],
   );
+}
+
+export function useSourcesForTriggerInput(input: IntentInputKeyConfig) {
+  return useMemo(() => paragon.getSourcesForActionInput(input), [input]);
 }
 
 export function useFieldOptions({
@@ -170,17 +177,29 @@ export function useInfiniteFieldOptions({
   });
 
   const flatData = useMemo(
-    () => query.data?.pages.flatMap((page) => page.data) ?? [],
+    () =>
+      query.data?.pages.flatMap((page) => flattenFieldOptions(page.data)) ?? [],
     [query.data?.pages],
   );
 
   return {
     data: flatData,
+    pages: query.data?.pages ?? [],
     fetchNextPage: query.fetchNextPage,
     hasNextPage: query.hasNextPage ?? false,
     isFetchingNextPage: query.isFetchingNextPage,
     isFetching: query.isFetching,
   };
+}
+
+export function useTriggerTypes(
+  integration: string,
+  selectedCredentialId: string,
+) {
+  return useQuery({
+    queryKey: ['triggerTypes', integration, { selectedCredentialId }],
+    queryFn: () => paragon.getTriggers(integration, { selectedCredentialId }),
+  });
 }
 
 export function useDataSourceOptions<T>(

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -194,7 +194,7 @@ export function useInfiniteFieldOptions({
 
 export function useTriggerTypes(
   integration: string,
-  selectedCredentialId: string,
+  selectedCredentialId?: string,
 ) {
   return useQuery({
     queryKey: ['triggerTypes', integration, { selectedCredentialId }],


### PR DESCRIPTION
### Issues Closed

- [PARA-20344](https://useparagon.atlassian.net/browse/PARA-20344)

### Summary

Adds a Triggers tab to the integration modal so users can subscribe to integration triggers, configure parameters, and define record filters. Pulls shared combobox/option logic into reusable helpers along the way.

### Steps to Test

1. Open an integration in the modal → confirm a third **Triggers** tab appears (disabled until a credential is selected).
2. Select a credential, open Triggers, subscribe to a trigger, fill parameters, add a filter record, save.
3. Saving is a no-op. Only logs the state for documentation.
4. Should work very similarly to how R5 does in Dashboard

### Screenshots

<img width="600" alt="CleanShot 2026-04-22 at 19 18 02@2x" src="https://github.com/user-attachments/assets/0107f91d-34ae-440d-844a-1f2cb41f0fd7" />